### PR TITLE
fixed health overflow bug

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -114,6 +114,7 @@ pub fn hunt_player(
             .translation
             .distance(player_transform.translation)
             < 30.0
+            && player_data.health != 0
         {
             // Close enough to act
             commands.entity(enemy).despawn();


### PR DESCRIPTION
CAUSE: when two enemies were stacked and player walked into them, caused double collision, lowering health below 0, causing integer overflow.
STATUS: FIXED